### PR TITLE
Work around pagination bug in Percipio API.

### DIFF
--- a/pkg/connector/client/percipio.go
+++ b/pkg/connector/client/percipio.go
@@ -136,8 +136,9 @@ func (c *Client) GetCourses(
 	query := map[string]interface{}{
 		"max":    limit,
 		"offset": offset,
-		// blank pagingRequestId is ignored.
-		"pagingRequestId": pagingRequestId,
+	}
+	if pagingRequestId != "" {
+		query["pagingRequestId"] = pagingRequestId
 	}
 	var target []Course
 	response, ratelimitData, err := c.get(ctx, ApiPathCoursesList, query, &target)


### PR DESCRIPTION
In the Zoom call today, the Percipio guy said that they changed their API to require pagingRequestId for next pages. Apparently that change also broke pagination if pagingRequestId was empty. So if we only add a pagingRequestId query arg if it's not empty, we get subsequent pages and the connector syncs.
