### PR TITLE
Fix HTTP Error Response Handling in Report Polling

### DIFF
--- a/cmd/baton-percipio/main.go
+++ b/cmd/baton-percipio/main.go
@@ -21,6 +21,9 @@ var (
 )
 
 func main() {
+	// Disable HTTP caching for this connector to ensure report polling always gets fresh results
+	os.Setenv("BATON_DISABLE_HTTP_CACHE", "true")
+
 	ctx := context.Background()
 
 	_, cmd, err := config.DefineConfiguration(


### PR DESCRIPTION
#### Description

- [x] Bug fix - Zscaler reported that Percipio sync failed and was down for six hours. This was due to the report polling workaround for preventing http caching. This PR fixes the issue and brings `pollLearningActivityReport` function back into alignment with the standard baton pattern of using uhttp for api calls, and also hard-codes the `BATON_DISABLE_HTTP_CACHE=true` environment variable as that was the only way I could find to prevent the polling caching during testing. 

## Problem

The `pollLearningActivityReport` function used native Go `net/http` to get around the challenge of disabling caching with uhttp, but the workaround didn't handle HTTP error responses and retries (which is built in to uhttp). If Percipio's API rate-limited the report polling endpoint, the connector would fail immediately without retrying, preventing grant synchronization.

## Root Cause

The native HTTP implementation was originally added because uhttp was caching GET responses, causing the polling to receive stale "IN_PROGRESS" statuses even after reports were ready. However, this workaround lost uhttp's built-in rate limit handling.

## Solution

Reverted the polling function to use uhttp and disabled HTTP caching globally for the connector:

1. Reverted `pollLearningActivityReport` to use the standard uhttp client (via the `get` method)
2. Set `BATON_DISABLE_HTTP_CACHE=true` in the main function to disable caching for the entire connector

This ensures:

- Report polling gets fresh responses (no caching)
- All endpoints properly handle HTTP errors with retry logic
- Consistent implementation patterns across all API methods

## Changes

- Reverted `pollLearningActivityReport` to use standard uhttp `get` method
- Added `os.Setenv("BATON_DISABLE_HTTP_CACHE", "true")` in main.go
- Properly handled the two-parameter URL format for report polling
- Removed native HTTP implementation and related imports

## Impact

- No functional changes for existing API calls
- Report polling now properly handles rate limiting
- Improved reliability for production deployments
- These changes were tested/validated in sandbox

#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
