### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-percipio/main.go
+++ b/cmd/baton-percipio/main.go
@@ -54,6 +54,7 @@ func getConnector(ctx context.Context, c *cfg.Percipio) (types.ConnectorServer, 
 		c.OrganizationId,
 		c.ApiToken,
 		c.LimitedCourses,
+		c.BaseUrl,
 	)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -7,6 +7,7 @@ type Percipio struct {
 	ApiToken string `mapstructure:"api-token"`
 	OrganizationId string `mapstructure:"organization-id"`
 	LimitedCourses []string `mapstructure:"limited-courses"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *Percipio) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,6 +27,7 @@ var (
 		"base-url",
 		field.WithDescription("Override the Percipio API URL (for testing)"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 
 	// ConfigurationFields defines the external configuration required for the

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,6 +23,11 @@ var (
 		field.WithRequired(false),
 	)
 
+	BaseURLField = field.StringField(
+		"base-url",
+		field.WithDescription("Override the Percipio API URL (for testing)"),
+	)
+
 	// ConfigurationFields defines the external configuration required for the
 	// connector to run. Note: these fields can be marked as optional or
 	// required.
@@ -30,6 +35,7 @@ var (
 		ApiTokenField,
 		OrganizationIdField,
 		LimitCoursesField,
+		BaseURLField,
 	}
 
 	// FieldRelationships defines relationships between the fields listed in

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,7 @@ var (
 	BaseURLField = field.StringField(
 		"base-url",
 		field.WithDescription("Override the Percipio API URL (for testing)"),
+		field.WithHidden(true),
 	)
 
 	// ConfigurationFields defines the external configuration required for the

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -73,10 +73,16 @@ func New(
 	organizationID string,
 	token string,
 	limitCourses []string,
+	baseURL string,
 ) (*Connector, error) {
+	apiURL := client.BaseApiUrl
+	if baseURL != "" {
+		apiURL = baseURL
+	}
+
 	percipioClient, err := client.New(
 		ctx,
-		client.BaseApiUrl,
+		apiURL,
 		organizationID,
 		token,
 	)


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-percipio/main.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/connector.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-percipio --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.