### PR TITLE
docs: update connector description

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: Set up a Percipio connector
 og:title: Set up a Percipio connector - C1 docs
-og:description: Integrate your Skillsoft Percipio instance with C1 to run user access reviews, enable just-in-time access requests, and easily provision and deprovision access.
-intro: C1 provides identity governance and just-in-time provisioning for Skillsoft Percipio. Integrate your Percipio instance with C1 to run user access reviews (UARs) and enable just-in-time access requests.
+og:description: "C1 provides identity governance for Percipio. Integrate your Percipio instance with C1 for unified visibility and governance over user access."
+description: "C1 provides identity governance for Percipio. Integrate your Percipio instance with C1 for unified visibility and governance over user access."
 sidebarTitle: Percipio
 ---
 
@@ -25,7 +25,7 @@ To set up the integration with C1, you'll need:
 
 Please work with your Skillsoft Account Team to set up a service account for the C1 integration and gather these credentials. 
 
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Configure the Percipio connector
 
@@ -84,7 +84,7 @@ Click **Save**.
 The connector's label changes to **Syncing**, followed by **Connected**. You can view the logs to ensure that information is syncing.
 </Step>
 </Steps>
-**That's it!** Your Percipio connector is now pulling access data into C1.
+**Done.** Your Percipio connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 
@@ -200,7 +200,7 @@ Create a namespace in which to run C1 connectors (if desired), then apply the se
 Check that the connector data uploaded correctly. In C1, click **Apps**. On the **Managed apps** tab, locate and click the name of the application you added the Percipio connector to. Percipio data should be found on the **Entitlements** and **Accounts** tabs.
 </Step>
 </Steps>
-**That's it!** Your Percipio connector is now pulling access data into C1.
+**Done.** Your Percipio connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
Replicates changes from [ConductorOne/docs#221](https://github.com/ConductorOne/docs/pull/221).

- Removes inaccurate provisioning claims from the connector description
- Updates `**That's it!**` to `**Done.**` to align with brand voice guidelines